### PR TITLE
Fix Typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ let msg = match state {
 
 ---
 
-## `Option<T>` instad of `nil`
+## `Option<T>` instead of `nil`
 
 ```rust
 // import packages from Go stdlib


### PR DESCRIPTION
## Changes
Fix the typo on line 54, `instad` to `instead`.

## Notes
borgo looks awesome :)