### PR TITLE
Remove rand.Seed(time.Now().UnixNano()) since it's no longer needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,6 @@ use time
 fn main() {
     let reader = bufio.NewReader(os.Stdin)
 
-    rand.Seed(time.Now().UnixNano())
     let secret = rand.Intn(100) + 1
 
     loop {


### PR DESCRIPTION
Since Go 1.10 rand is seeded when the program starts.