### PR TITLE
fix flake.nix to work on all platforms

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,6 +5,24 @@
         "systems": "systems"
       },
       "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
         "lastModified": 1692799911,
         "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
         "owner": "numtide",
@@ -52,13 +70,14 @@
     },
     "root": {
       "inputs": {
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"
       }
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": "flake-utils",
+        "flake-utils": "flake-utils_2",
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
@@ -76,6 +95,21 @@
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -1,34 +1,36 @@
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
     rust-overlay.url = "github:oxalica/rust-overlay";
   };
 
   outputs = {
     self,
     nixpkgs,
+    flake-utils,
     rust-overlay,
-  }: let
-    # TODO what's the correct incantation here?
-    system = "x86_64-linux";
+  }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+    	  inherit system;
+    	  overlays = [rust-overlay.overlays.default];
+    	};
 
-    pkgs = import nixpkgs {
-      inherit system;
-      overlays = [rust-overlay.overlays.default];
-    };
+    	toolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
 
-    toolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
-
-  in {
-    devShells.${system}.default = pkgs.mkShell {
-      packages = [
-        toolchain
-        pkgs.go_1_19
-        pkgs.just
-        pkgs.deno
-        pkgs.gofumpt
-      ];
-    };
-  };
+      in {
+        devShells.default = pkgs.mkShell {
+          packages = [
+            toolchain
+            pkgs.go_1_19
+            pkgs.just
+            pkgs.deno
+            pkgs.gofumpt
+          ];
+        };
+      }
+    );
 }
 


### PR DESCRIPTION
Fix `flake.nix` to fetch the appropriate nixpkgs repo for your platform, and generate a dev shell for it as well.

Some background: https://fasterthanli.me/series/building-a-rust-service-with-nix/part-10#a-flake-with-a-dev-shell


I've tested this on my Apple Silicon Mac:

**Before**:
![image](https://github.com/borgo-lang/borgo/assets/332583/6a431d70-7603-48a9-b9c4-315cf0122e11)


**After**:
![image](https://github.com/borgo-lang/borgo/assets/332583/b4b46771-c5c7-4be2-950e-7ccbf16f7b5b)
