### PR TITLE
Add struct tags support for compiler and importer

### DIFF
--- a/compiler/src/ast.rs
+++ b/compiler/src/ast.rs
@@ -270,6 +270,7 @@ pub struct StructFieldDef {
     pub name: Ident,
     pub ann: TypeAst,
     pub ty: BoundedType,
+    pub tags: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/compiler/src/codegen.rs
+++ b/compiler/src/codegen.rs
@@ -1189,7 +1189,11 @@ if {is_matching} != 2 {{
         def.fields.iter().for_each(|f| {
             let field = &f.name;
             let ty = self.to_type(&f.ty.ty);
-            out.emit(format!("  {field} {ty}"));
+            let tags = &f.tags;
+            match tags {
+                Some(tg) => out.emit(format!("  {field} {ty} `{tg}`")),
+                None =>  out.emit(format!("  {field} {ty}")),
+            }
         });
 
         out.emit("}".to_string());

--- a/compiler/src/infer.rs
+++ b/compiler/src/infer.rs
@@ -2526,6 +2526,7 @@ has no field or method:
                     name,
                     ann: f.ann.clone(),
                     ty: typ.to_bounded(),
+                    tags: None
                 }
             })
             .collect();
@@ -3169,6 +3170,7 @@ has no field or method:
                 name: sym.name.clone(),
                 ann: TypeAst::Unknown,
                 ty: ty.clone(),
+                tags: None
             });
         }
 

--- a/compiler/src/lexer.rs
+++ b/compiler/src/lexer.rs
@@ -527,7 +527,7 @@ impl Lexer {
         }
     }
 
-    fn scan_string(&mut self) -> Token {
+    fn scan_string(&mut self, delimiter: char) -> Token {
         let mut text = String::new();
 
         let start = self.next();
@@ -535,7 +535,7 @@ impl Lexer {
 
         // TODO validate escape \"
         loop {
-            if self.ch == '"' {
+            if self.ch == delimiter {
                 self.next();
                 seen_closing = true;
                 break;
@@ -681,7 +681,7 @@ impl Lexer {
         match self.ch {
             '0'..='9' => self.scan_number(),
             'a'..='z' | 'A'..='Z' | '_' => self.scan_ident(),
-            '"' => self.scan_string(),
+            '"' | '`' => self.scan_string(self.ch),
             '\'' => self.scan_char(),
             '/' => self.scan_slash_comment(),
             '\\' => self.scan_multi_string(),

--- a/compiler/src/parser.rs
+++ b/compiler/src/parser.rs
@@ -1768,11 +1768,24 @@ impl Parser {
         let name = self.parse_one_ident();
         self.expect(TokenKind::Colon);
         let ann = self.parse_type();
+        let tags = self.parse_struct_field_tags();
 
         StructFieldDef {
             name,
             ann,
             ty: Type::dummy().to_bounded(),
+            tags
+        }
+    }
+
+    fn parse_struct_field_tags(&mut self) -> Option<String> {
+        match self.tok.kind {
+            TokenKind::String => {
+                let tags = Some(self.tok.text.clone());
+                self.next();
+                tags
+            }
+            _ => None,
         }
     }
 

--- a/importer/testpkg/testpkg.go
+++ b/importer/testpkg/testpkg.go
@@ -14,8 +14,8 @@ const (
 const SomeConst = 1
 
 type Person struct {
-	Name    string
-	Hobbies []Hobby
+	Name    string `json:"name"`
+	Hobbies []Hobby `json:"hobbies"`
 }
 
 type Hobby struct {


### PR DESCRIPTION
Resolves #3 

I did not do anything with the test runner as I am not quite sure what to do with it so tips would be appreciated if anything needs to be done

This implementation implicitly makes it so strings support backticks, not only ".
If this is not an option I should extend the parser to go through Token:idents between backticks or introduce another token type only for tags?

